### PR TITLE
cmake: don't limit generation of pkg-config file to only unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(libMXF
     LANGUAGES C CXX
 )
 
+include(GNUInstallDirs) # provides access to ${CMAKE_INSTALL_BINDIR} etc.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
 if(MSVC AND LIBMXF_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)

--- a/examples/archive/info/CMakeLists.txt
+++ b/examples/archive/info/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(archive_mxf_info
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(archive_mxf_info "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
-install(TARGETS archive_mxf_info DESTINATION bin)
+install(TARGETS archive_mxf_info DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/examples/archive/write/CMakeLists.txt
+++ b/examples/archive/write/CMakeLists.txt
@@ -32,10 +32,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(writearchivemxf "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
 install(TARGETS writearchivemxf
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES ${writearchivemxf_headers} DESTINATION include/mxf/examples/archive)
+install(FILES ${writearchivemxf_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf/examples/archive)
 
 
 add_executable(update_archive_mxf

--- a/examples/avidmxfinfo/CMakeLists.txt
+++ b/examples/avidmxfinfo/CMakeLists.txt
@@ -25,10 +25,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(avidmxfinfo "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
 install(TARGETS avidmxfinfo
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES ${avidmxfinfo_headers} DESTINATION include/mxf/examples/avidmxfinfo)
+install(FILES ${avidmxfinfo_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf/examples/avidmxfinfo)
 
 
 add_executable(avidmxfinfo-bin
@@ -46,7 +46,7 @@ set_target_properties(avidmxfinfo-bin PROPERTIES
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(avidmxfinfo-bin "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
-install(TARGETS avidmxfinfo-bin DESTINATION bin)
+install(TARGETS avidmxfinfo-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 
 if(LIBMXF_BUILD_TESTING AND (NOT DEFINED BUILD_TESTING OR BUILD_TESTING))

--- a/examples/reader/CMakeLists.txt
+++ b/examples/reader/CMakeLists.txt
@@ -30,10 +30,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(mxfreader "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
 install(TARGETS mxfreader
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES ${mxfreader_headers} DESTINATION include/mxf/examples/reader)
+install(FILES ${mxfreader_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf/examples/reader)
 
 
 if(LIBMXF_BUILD_TESTING AND (NOT DEFINED BUILD_TESTING OR BUILD_TESTING))

--- a/examples/writeavidmxf/CMakeLists.txt
+++ b/examples/writeavidmxf/CMakeLists.txt
@@ -30,10 +30,10 @@ set_source_filename(writeavidmxf "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 # Only install if build is enabled, and not only for testing avidmxfinfo & reader
 if(LIBMXF_BUILD_EXAMPLES OR LIBMXF_BUILD_WRITEAVIDMXF)
     install(TARGETS writeavidmxf
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-    install(FILES ${writeavidmxf_headers} DESTINATION include/mxf/examples/writeavidmxf)
+    install(FILES ${writeavidmxf_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf/examples/writeavidmxf)
 endif()
 
 
@@ -57,7 +57,7 @@ set_source_filename(writeavidmxf-bin "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
 # Only install if build is enabled, and not only for testing avidmxfinfo & reader
 if(LIBMXF_BUILD_EXAMPLES OR LIBMXF_BUILD_WRITEAVIDMXF)
-    install(TARGETS writeavidmxf-bin DESTINATION bin)
+    install(TARGETS writeavidmxf-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 

--- a/libMXF.pc.in
+++ b/libMXF.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@

--- a/mxf/CMakeLists.txt
+++ b/mxf/CMakeLists.txt
@@ -130,7 +130,5 @@ install(TARGETS MXF
 
 install(FILES ${MXF_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf)
 
-if(UNIX)
-    configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif()
+configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/mxf/CMakeLists.txt
+++ b/mxf/CMakeLists.txt
@@ -124,13 +124,13 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(MXF "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
 install(TARGETS MXF
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(FILES ${MXF_headers} DESTINATION include/mxf)
+install(FILES ${MXF_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mxf)
 
 if(UNIX)
     configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION lib/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/tools/MXFDump/CMakeLists.txt
+++ b/tools/MXFDump/CMakeLists.txt
@@ -10,4 +10,4 @@ endif()
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(MXFDump "${CMAKE_CURRENT_LIST_DIR}" "libMXF")
 
-install(TARGETS MXFDump DESTINATION bin)
+install(TARGETS MXFDump DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Dependent on https://github.com/bbc/libMXF/pull/6

Makes it so that it generates the .pc file when using non-unix systems like with mingw-w64 cmake from msys2.